### PR TITLE
added enable_epel param (disabled by default)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ script: "bundle exec rake spec"
 rvm:
   - 1.8.7
   - 1.9.3
-  - ruby-head
 notifications:
   hipchat:
     rooms:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 ## Installs and configures redis from epel
-class redis {
+class redis( $enable_epel = false ) {
 
   case $::osfamily {
     'RedHat': {
@@ -7,8 +7,10 @@ class redis {
       $service_name    = 'redis'
       $redis_conf_path = '/etc/redis.conf'
 
-      include epel
-      Class['epel'] -> Package['redis']
+      if $enable_epel {
+        include epel
+        Class['epel'] -> Package['redis']
+      }
     }
     'Debian': {
       $package_name    = 'redis-server'

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -8,8 +8,28 @@ describe 'redis', :type => :class do
       }
     end
 
-    it 'should install epel' do
-      should include_class('epel')
+    context 'when enable_epel is true' do
+      let(:params) do
+        {
+          :enable_epel => true
+        }
+      end
+
+      it 'should install epel' do
+        should include_class('epel')
+      end
+    end
+
+    context 'when enable_epel is false' do
+      let(:params) do
+        {
+          :enable_epel => false
+        }
+      end
+
+      it 'should not install epel' do
+        should_not include_class('epel')
+      end
     end
 
     it 'should setup redis' do

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,1 +1,3 @@
-include redis
+class { 'redis':
+  enable_epel => true,
+}


### PR DESCRIPTION
If you're like me, you're mirroring things like the epel repo within your own site, and having a puppet module automatically pull down a public repo really screws up your yum feng shui. We fix this by disabling this behavior by default, but adding a simple class parameter to turn it back on again. Thanks to @dummydata for the hot tip.
